### PR TITLE
Allowed API to set different corpora for different simultaneous jobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
     </build>
     <dependencies>
 
+      <dependency>
+	<groupId>org.jyaml</groupId>
+	<artifactId>jyaml</artifactId>
+	<version>1.3</version>
+      </dependency>
         <dependency>
             <groupId>org.la4j</groupId>
             <artifactId>la4j</artifactId>
@@ -78,8 +83,8 @@
             <groupId>edu.nyu.cs.proteus</groupId>
             <artifactId>Jet</artifactId>
             <version>1.8.2-depfix</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/lib/jet-all-1.8.1.jar</systemPath>
+            <!-- scope>system</scope>
+            <systemPath>{project.basedir}/lib/jet-all-1.8.1.jar</systemPath -->
         </dependency>
 
         <dependency>
@@ -92,6 +97,11 @@
             <artifactId>commons-exec</artifactId>
             <version>1.1</version>
         </dependency>
+	<dependency>
+	  <groupId>net.sf.trove4j</groupId>
+	  <artifactId>trove4j</artifactId>
+	  <version>3.0.3</version>
+	</dependency>
     </dependencies>
 
 </project>

--- a/src/main/java/edu/nyu/jet/ice/entityset/EntitySetExpander.java
+++ b/src/main/java/edu/nyu/jet/ice/entityset/EntitySetExpander.java
@@ -52,6 +52,7 @@ public class EntitySetExpander {
      * @return
      */
     public static List<String> recommendSeeds(String indexFileName, String termFileName, String type) {
+        System.out.println("EntitySetExpander.recommendSeeds(" + indexFileName + ", " + termFileName + ", " + type + ")");
         Map<String, Vector> entityFeatureDict = new HashMap<String, Vector>();
         String line;
         try {
@@ -110,7 +111,7 @@ public class EntitySetExpander {
         } catch (IOException e) {
             e.printStackTrace();
         }
-
+	System.out.println("Found " + Integer.toString(dataPoints.size()) + " dataPoints");
         List<DataPointCluster> dataPointClusters = new ArrayList<DataPointCluster>();
         for (DataPoint p : dataPoints) {
             dataPointClusters.add(new DataPointCluster(p));

--- a/src/main/java/edu/nyu/jet/ice/models/Corpus.java
+++ b/src/main/java/edu/nyu/jet/ice/models/Corpus.java
@@ -42,7 +42,7 @@ public class Corpus {
     public String backgroundCorpus;
     public String termFileName;
     // for relation finder
-    public String relationTypeFileName;
+    public String relationTypesFileName;
     public String relationInstanceFileName;
     public RelationBuilder relationBuilder;
 
@@ -119,9 +119,17 @@ public class Corpus {
         termFileName = s;
     }
 
-    public String getRelationTypeFileName() {
-        return relationTypeFileName;
+    public String getRelationTypesFileName() {
+        return relationTypesFileName;
     }
+
+	public void setRelationTypesFileName(String s) {
+		this.relationTypesFileName = s;
+	}
+
+	public void setRelationInstanceFileName(String s) {
+		this.relationInstanceFileName = s;
+	}
 
     ProgressMonitorI wordProgressMonitor;
 
@@ -181,7 +189,7 @@ public class Corpus {
 //                run("Terms", "utils/findTerms " + wordCountFileName + " " +
 //                        Ice.corpora.get(backgroundCorpus).wordCountFileName + " " +
 //                        termFileName);
-        String ratioFileName = Ice.selectedCorpusName + "-" + backgroundCorpus + "-" + "Ratio";
+        String ratioFileName = this.name + "-" + backgroundCorpus + "-" + "Ratio";
         try {
             //Ratio.main(new String[] {wordCountFileName, Ice.corpora.get(backgroundCorpus).wordCountFileName, ratioFileName});
             //IceUtils.numsort(ratioFileName, termFileName);
@@ -319,9 +327,9 @@ public class Corpus {
 
 
     public void checkForAndFindRelations(ProgressMonitorI progressMonitor, RelationFilter relationFilter) {
-        relationInstanceFileName = FileNameSchema.getRelationsFileName(Ice.selectedCorpusName);//name + "Relations";
-        relationTypeFileName = FileNameSchema.getRelationTypesFileName(Ice.selectedCorpusName);//name + "Relationtypes";
-        File file = new File(relationTypeFileName);
+        relationInstanceFileName = FileNameSchema.getRelationsFileName(this.name);//name + "Relations";
+        relationTypesFileName = FileNameSchema.getRelationTypesFileName(this.name);//name + "Relationtypes";
+        File file = new File(relationTypesFileName);
         if (file.exists() &&
                 !file.isDirectory()) {
             int n = JOptionPane.showConfirmDialog(
@@ -330,7 +338,7 @@ public class Corpus {
                     "Patterns exist",
                     JOptionPane.YES_NO_OPTION);
             if (n == 0) {
-                Corpus.displayTerms(relationTypeFileName,
+                Corpus.displayTerms(relationTypesFileName,
                         40,
                         relationTextArea,
                         relationFilter);
@@ -344,28 +352,28 @@ public class Corpus {
 
     public void findRelations(ProgressMonitorI progressMonitor, String docListPrefix, JTextArea publishToTextArea) {
         relationInstanceFileName = FileNameSchema.getRelationsFileName(name);
-        relationTypeFileName = FileNameSchema.getRelationTypesFileName(name);
+        relationTypesFileName = FileNameSchema.getRelationTypesFileName(name);
         docListFileName = FileNameSchema.getDocListFileName(name);
 
 
         RelationFinder finder = new RelationFinder(
                 docListFileName, directory, filter, relationInstanceFileName,
-                relationTypeFileName, publishToTextArea, numberOfDocs,
+                relationTypesFileName, publishToTextArea, numberOfDocs,
                 progressMonitor);
         finder.start();
     }
 
     public void rankRelations() {
         String ratioFileName = FileNameSchema.getPatternRatioFileName(name, backgroundCorpus);
-        rankRelations(backgroundCorpus, ratioFileName);
+        rankRelations(this.name, backgroundCorpus, ratioFileName);
     }
 
-    public static void rankRelations(String bgCorpus, String fileName) {
+    public static void rankRelations(String fgCorpus, String bgCorpus, String fileName) {
         try {
             String sortedRatioFileName = fileName + ".sorted";
             Ratio.main(new String[]{
-                    Ice.selectedCorpus.relationTypeFileName,
-                    Ice.corpora.get(bgCorpus).relationTypeFileName,
+                    FileNameSchema.getRelationTypesFileName(fgCorpus),
+                    FileNameSchema.getRelationTypesFileName(bgCorpus),
                     fileName
             });
             IceUtils.numsort(fileName, sortedRatioFileName);
@@ -408,10 +416,10 @@ public class Corpus {
         JScrollPane scrollPane = new JScrollPane(relationTextArea);
         relationFilter.setArea(relationTextArea);
 
-        if (relationTypeFileName != null)
-            //Corpus.displayTerms(relationTypeFileName, 40, relationTextArea, null);
+        if (relationTypesFileName != null)
+            //Corpus.displayTerms(relationTypesFileName, 40, relationTextArea, null);
 
-            Corpus.displayTerms(relationTypeFileName, 40, relationTextArea, relationFilter);
+            Corpus.displayTerms(relationTypesFileName, 40, relationTextArea, relationFilter);
         box.add(scrollPane);
 
         // listener -----
@@ -462,10 +470,10 @@ public class Corpus {
         JScrollPane scrollPane = new JScrollPane(relationTextArea);
         relationFilter.setArea(relationTextArea);
 
-        if (relationTypeFileName != null)
-            //Corpus.displayTerms(relationTypeFileName, 40, relationTextArea, null);
+        if (relationTypesFileName != null)
+            //Corpus.displayTerms(relationTypesFileName, 40, relationTextArea, null);
 
-            Corpus.displayTerms(relationTypeFileName, 40, relationTextArea, relationFilter);
+            Corpus.displayTerms(relationTypesFileName, 40, relationTextArea, relationFilter);
         box.add(scrollPane);
 
         // listener -----
@@ -555,14 +563,15 @@ public class Corpus {
     }
 
     public List<String> getRelations(int limit) {
-        relationTypeFileName = FileNameSchema.getRelationTypesFileName(name);
-        return getTerms(relationTypeFileName, limit, Corpus.relationFilter);
+        relationTypesFileName = FileNameSchema.getRelationTypesFileName(name);
+        return getTerms(relationTypesFileName, limit, Corpus.relationFilter);
     }
 
     public static List<String> getTerms(String termFile, int limit, ListFilter tf) {
+		String corpusName = FileNameSchema.getCorpusNameFromTermsFile(termFile);
         List<String> topTerms = new ArrayList<String>();
         int k = 0;
-        DepPathMap depPathMap = DepPathMap.getInstance();
+        DepPathMap depPathMap = DepPathMap.getInstance(corpusName);
         boolean displayRelation = false;
         if (tf != null && tf instanceof RelationFilter) {
             // depPathMap.clear();

--- a/src/main/java/edu/nyu/jet/ice/models/DepPathMap.java
+++ b/src/main/java/edu/nyu/jet/ice/models/DepPathMap.java
@@ -13,13 +13,26 @@ import java.util.*;
  * handles serialization/deserialization of the map.
  */
 public class DepPathMap {
+
+    private String corpusName;
+
     private static DepPathMap instance = null;
 
     private HashMap<String, String> pathReprMap = new HashMap<String, String>();
     private HashMap<String, List<String>> reprPathMap = new HashMap<String, List<String>>();
     private HashMap<String, String> pathExampleMap = new HashMap<String, String>();
-    private DepPathMap() { }
+    private DepPathMap(String corpusName) {
+	this.corpusName = corpusName;
+    }
     private String previousFileName = null;
+
+    public void setCorpusName (String corpusName) {
+	this.corpusName = corpusName;
+    }
+
+    public String getCorpusName () {
+	return this.corpusName;
+    }
 
     private Set<String> leftRelations = new HashSet<String>();
     {
@@ -42,9 +55,9 @@ public class DepPathMap {
     /**
     DepPathMap is a singleton which is shared across the program.
      */
-    public static DepPathMap getInstance() {
-        if (instance == null) {
-            instance = new DepPathMap();
+    public static DepPathMap getInstance(String corpusName) {
+        if (instance == null || !instance.corpusName.equals(corpusName)) {
+            instance = new DepPathMap(corpusName);
         }
         return instance;
     }
@@ -68,7 +81,7 @@ public class DepPathMap {
     }
 
     public void unpersist() {
-        String fileName = FileNameSchema.getRelationReprFileName(Ice.selectedCorpusName);
+        String fileName = FileNameSchema.getRelationReprFileName(this.corpusName);
         try {
             File f = new File(fileName);
             f.delete();
@@ -80,7 +93,7 @@ public class DepPathMap {
     }
 
     public void persist() {
-        String fileName = FileNameSchema.getRelationReprFileName(Ice.selectedCorpusName);
+        String fileName = FileNameSchema.getRelationReprFileName(this.corpusName);
         try {
             PrintWriter pw = new PrintWriter(new FileWriter(fileName));
             for (String path : pathReprMap.keySet()) {
@@ -98,7 +111,7 @@ public class DepPathMap {
     }
 
     public boolean forceLoad() {
-        String fileName = FileNameSchema.getRelationReprFileName(Ice.selectedCorpusName);
+        String fileName = FileNameSchema.getRelationReprFileName(this.corpusName);
         File f = new File(fileName);
         if (!f.exists() || f.isDirectory()) return false;
         // if (previousFileName != null && previousFileName.equals(fileName)) return true; // use old data
@@ -136,7 +149,7 @@ public class DepPathMap {
     }
 
     public boolean load() {
-        String fileName = FileNameSchema.getRelationReprFileName(Ice.selectedCorpusName);
+        String fileName = FileNameSchema.getRelationReprFileName(this.corpusName);
         File f = new File(fileName);
         if (!f.exists() || f.isDirectory()) return false;
         if (previousFileName != null && previousFileName.equals(fileName) && pathExampleMap.size() > 0) return true; // use old data

--- a/src/main/java/edu/nyu/jet/ice/models/PathMatcher.java
+++ b/src/main/java/edu/nyu/jet/ice/models/PathMatcher.java
@@ -1,6 +1,6 @@
 package edu.nyu.jet.ice.models;
 
-import gnu.trove.TObjectDoubleHashMap;
+import gnu.trove.map.hash.TObjectDoubleHashMap;
 
 import java.io.BufferedReader;
 import java.io.FileReader;

--- a/src/main/java/edu/nyu/jet/ice/models/RelationFinder.java
+++ b/src/main/java/edu/nyu/jet/ice/models/RelationFinder.java
@@ -1,6 +1,7 @@
 package edu.nyu.jet.ice.models;
 
 import edu.nyu.jet.ice.uicomps.Ice;
+import edu.nyu.jet.ice.utils.FileNameSchema;
 import edu.nyu.jet.ice.utils.ProgressMonitorI;
 import edu.nyu.jet.ice.utils.SwingProgressMonitor;
 
@@ -50,7 +51,8 @@ public class RelationFinder extends Thread {
             if (null != relationProgressMonitor) {
                 relationProgressMonitor.setProgress(2);
             }
-            DepPathMap depPathMap = DepPathMap.getInstance();
+	    String corpusName = FileNameSchema.getCorpusNameFromDocList(args[1]);
+            DepPathMap depPathMap = DepPathMap.getInstance(corpusName);
             depPathMap.unpersist();
             DepPaths.progressMonitor = relationProgressMonitor;
             DepPaths.main(args);

--- a/src/main/java/edu/nyu/jet/ice/relation/ArgEmbeddingBootstrap.java
+++ b/src/main/java/edu/nyu/jet/ice/relation/ArgEmbeddingBootstrap.java
@@ -50,8 +50,9 @@ public class ArgEmbeddingBootstrap extends Bootstrap {
 
     @Override
     public List<IcePath> initialize(String seedPath, String patternFileName) {
+	String corpusName = FileNameSchema.getCorpusNameFromPatternFileName(patternFileName);
         try {
-            DepPathMap depPathMap = DepPathMap.getInstance();
+            DepPathMap depPathMap = DepPathMap.getInstance(corpusName);
             String[] splitPaths = seedPath.split(":::");
 //            String firstSeedPath = null;
             List<String> allPaths = new ArrayList<String>();
@@ -85,7 +86,7 @@ public class ArgEmbeddingBootstrap extends Bootstrap {
 //                    + File.separator +"deps.context.complete.vec.dim200");
             pathSet = new ArgEmbeddingAnchoredPathSet(patternFileName, normalizedPhraseEmbeddings, 0.8);
 //            pathSet = new AnchoredPathSet(patternFileName);
-            bootstrap(arg1Type, arg2Type);
+            bootstrap(corpusName, arg1Type, arg2Type);
         }
         catch (IOException e) {
             e.printStackTrace();
@@ -95,10 +96,10 @@ public class ArgEmbeddingBootstrap extends Bootstrap {
     }
 
     @Override
-    public List<IcePath> iterate(List<IcePath> approvedPaths, List<IcePath> rejectedPaths) {
+	public List<IcePath> iterate(String corpusName, List<IcePath> approvedPaths, List<IcePath> rejectedPaths) {
         addPathsToSeedSet(approvedPaths, seedPaths);
         addPathsToSeedSet(rejectedPaths, rejects);
-        bootstrap(arg1Type, arg2Type);
+        bootstrap(corpusName, arg1Type, arg2Type);
         return foundPatterns;
     }
 
@@ -127,7 +128,7 @@ public class ArgEmbeddingBootstrap extends Bootstrap {
         }
     }
 
-    private void bootstrap(String arg1Type, String arg2Type) {
+    private void bootstrap(String corpusName, String arg1Type, String arg2Type) {
         if (Ice.iceProperties.getProperty("Ice.Bootstrapper.debug") != null) {
             DEBUG = Boolean.valueOf(Ice.iceProperties.getProperty("Ice.Bootstrapper.debug"));
         }
@@ -135,7 +136,7 @@ public class ArgEmbeddingBootstrap extends Bootstrap {
             DIVERSIFY = Boolean.valueOf(Ice.iceProperties.getProperty("Ice.Bootstrapper.diversify"));
         }
         foundPatterns.clear();
-        DepPathMap depPathMap = DepPathMap.getInstance();
+        DepPathMap depPathMap = DepPathMap.getInstance(corpusName);
 
         double minAllowedSimilarity =
                 PathRelationExtractor.minThreshold * PathRelationExtractor.negDiscount * SCREEN_DIVERSITY_DISCOUNT;

--- a/src/main/java/edu/nyu/jet/ice/relation/Bootstrap.java
+++ b/src/main/java/edu/nyu/jet/ice/relation/Bootstrap.java
@@ -8,6 +8,7 @@ import edu.nyu.jet.ice.models.IcePath;
 import edu.nyu.jet.ice.models.PathMatcher;
 import edu.nyu.jet.ice.uicomps.Ice;
 import edu.nyu.jet.ice.utils.IceUtils;
+import edu.nyu.jet.ice.utils.FileNameSchema;
 import edu.nyu.jet.ice.utils.ProgressMonitorI;
 import gnu.trove.TObjectDoubleHashMap;
 
@@ -98,8 +99,9 @@ public class Bootstrap {
     }
 
     public List<IcePath> initialize(String seedPath, String patternFileName) {
+		String corpusName = FileNameSchema.getCorpusNameFromPatternFileName(patternFileName);
         try {
-            DepPathMap depPathMap = DepPathMap.getInstance();
+            DepPathMap depPathMap = DepPathMap.getInstance(corpusName);
             String[] splitPaths = seedPath.split(":::");
 //            String firstSeedPath = null;
             List<String> allPaths = new ArrayList<String>();
@@ -131,7 +133,7 @@ public class Bootstrap {
             // Using SimAchoredPathSet
 //            pathSet = new SimAnchoredPathSet(patternFileName, pathMatcher, 0.6);
             pathSet = new AnchoredPathSet(patternFileName);
-            bootstrap(arg1Type, arg2Type);
+            bootstrap(corpusName, arg1Type, arg2Type);
         }
         catch (IOException e) {
             e.printStackTrace();
@@ -140,10 +142,10 @@ public class Bootstrap {
         return foundPatterns;
     }
 
-    public List<IcePath> iterate(List<IcePath> approvedPaths, List<IcePath> rejectedPaths) {
+    public List<IcePath> iterate(String corpusName, List<IcePath> approvedPaths, List<IcePath> rejectedPaths) {
         addPathsToSeedSet(approvedPaths, seedPaths);
         addPathsToSeedSet(rejectedPaths, rejects);
-        bootstrap(arg1Type, arg2Type);
+        bootstrap(corpusName, arg1Type, arg2Type);
         return foundPatterns;
     }
 
@@ -159,7 +161,7 @@ public class Bootstrap {
         this.progressMonitor = progressMonitor;
     }
 
-    private void bootstrap(String arg1Type, String arg2Type) {
+    private void bootstrap(String corpusName, String arg1Type, String arg2Type) {
         // DEBUG = Show various distance scores (used to select instances) in tooltip
         if (Ice.iceProperties.getProperty("Ice.Bootstrapper.debug") != null) {
             DEBUG = Boolean.valueOf(Ice.iceProperties.getProperty("Ice.Bootstrapper.debug"));
@@ -169,7 +171,7 @@ public class Bootstrap {
             DIVERSIFY = Boolean.valueOf(Ice.iceProperties.getProperty("Ice.Bootstrapper.diversify"));
         }
         foundPatterns.clear();
-        DepPathMap depPathMap = DepPathMap.getInstance();
+        DepPathMap depPathMap = DepPathMap.getInstance(corpusName);
 
         double minAllowedSimilarity =
                 PathRelationExtractor.minThreshold * PathRelationExtractor.negDiscount * SCREEN_DIVERSITY_DISCOUNT;

--- a/src/main/java/edu/nyu/jet/ice/relation/LexicalSimilarityBootstrap.java
+++ b/src/main/java/edu/nyu/jet/ice/relation/LexicalSimilarityBootstrap.java
@@ -8,6 +8,7 @@ import edu.nyu.jet.ice.models.IcePath;
 import edu.nyu.jet.ice.models.PathMatcher;
 import edu.nyu.jet.ice.uicomps.Ice;
 import edu.nyu.jet.ice.utils.IceUtils;
+import edu.nyu.jet.ice.utils.FileNameSchema;
 import edu.nyu.jet.ice.utils.ProgressMonitorI;
 import gnu.trove.TObjectDoubleHashMap;
 
@@ -47,8 +48,9 @@ public class LexicalSimilarityBootstrap extends Bootstrap {
 
     @Override
     public List<IcePath> initialize(String seedPath, String patternFileName) {
+	String corpusName = FileNameSchema.getCorpusNameFromPatternFileName(patternFileName);
         try {
-            DepPathMap depPathMap = DepPathMap.getInstance();
+            DepPathMap depPathMap = DepPathMap.getInstance(corpusName);
             String[] splitPaths = seedPath.split(":::");
 //            String firstSeedPath = null;
             List<String> allPaths = new ArrayList<String>();
@@ -80,7 +82,7 @@ public class LexicalSimilarityBootstrap extends Bootstrap {
             // Using SimAchoredPathSet
             pathSet = new SimAnchoredPathSet(patternFileName, pathMatcher, 0.6);
 //            pathSet = new AnchoredPathSet(patternFileName);
-            bootstrap(arg1Type, arg2Type);
+            bootstrap(corpusName, arg1Type, arg2Type);
         }
         catch (IOException e) {
             e.printStackTrace();
@@ -89,14 +91,14 @@ public class LexicalSimilarityBootstrap extends Bootstrap {
         return foundPatterns;
     }
 
-    public List<IcePath> iterate(List<IcePath> approvedPaths, List<IcePath> rejectedPaths) {
+    public List<IcePath> iterate(String corpusName, List<IcePath> approvedPaths, List<IcePath> rejectedPaths) {
         addPathsToSeedSet(approvedPaths, seedPaths);
         addPathsToSeedSet(rejectedPaths, rejects);
-        bootstrap(arg1Type, arg2Type);
+        bootstrap(corpusName, arg1Type, arg2Type);
         return foundPatterns;
     }
 
-    private void bootstrap(String arg1Type, String arg2Type) {
+    private void bootstrap(String corpusName, String arg1Type, String arg2Type) {
         if (Ice.iceProperties.getProperty("Ice.Bootstrapper.debug") != null) {
             DEBUG = Boolean.valueOf(Ice.iceProperties.getProperty("Ice.Bootstrapper.debug"));
         }
@@ -104,7 +106,7 @@ public class LexicalSimilarityBootstrap extends Bootstrap {
             DIVERSIFY = Boolean.valueOf(Ice.iceProperties.getProperty("Ice.Bootstrapper.diversify"));
         }
         foundPatterns.clear();
-        DepPathMap depPathMap = DepPathMap.getInstance();
+        DepPathMap depPathMap = DepPathMap.getInstance(corpusName);
 
         double minAllowedSimilarity =
                 PathRelationExtractor.minThreshold * PathRelationExtractor.negDiscount * SCREEN_DIVERSITY_DISCOUNT;

--- a/src/main/java/edu/nyu/jet/ice/terminology/TermCounter.java
+++ b/src/main/java/edu/nyu/jet/ice/terminology/TermCounter.java
@@ -64,6 +64,11 @@ public class TermCounter extends Thread {
             progressMonitor.setNote("Loading Jet models...");
             progressMonitor.setProgress(1);
         }
+	System.out.println ("TermCounter.count(" + propsFile + ", , " + inputDir + ", " + inputSuffix + ", " + outputFile + ")");
+	String corpusName = FileNameSchema.getCorpusNameFromWordCountFileName(outputFile);
+	System.out.println("CorpusName = " + corpusName);
+	String cacheDir = FileNameSchema.getPreprocessCacheDir(corpusName);
+	System.out.println("cacheDir = " + cacheDir);
         try {
             Thread.sleep(500);
             if (progressMonitor != null) {
@@ -105,7 +110,7 @@ public class TermCounter extends Thread {
                 // process document
                 Ace.monocase = Ace.allLowerCase(doc);
                 Control.processDocument(doc, null, false, docCount);
-                addDocument(doc, FileNameSchema.getPreprocessCacheDir(Ice.selectedCorpusName), inputDir, inputFile);
+                addDocument(doc, cacheDir, inputDir, inputFile);
                 if (progressMonitor != null) {
                     progressMonitor.setProgress(docCount);
                     progressMonitor.setNote(docCount + " files processed");

--- a/src/main/java/edu/nyu/jet/ice/uicomps/EntitySetBuilder.java
+++ b/src/main/java/edu/nyu/jet/ice/uicomps/EntitySetBuilder.java
@@ -44,7 +44,23 @@ public class EntitySetBuilder {
 
     public void buildIndex(double cutoff, String inType) {
 
-        Corpus selectedCorpus = Ice.selectedCorpus;
+        String corpusName = Ice.selectedCorpusName;
+		buildIndex(corpusName, cutoff, inType);
+	}
+
+	public void buildIndex (String corpusName, double cutoff, String inType) {
+		Corpus selectedCorpus = Ice.corpora.get(corpusName);
+        /**
+         * String countFile   = args[0];
+         String type        = args[1];
+         double cutoff      = Double.valueOf(args[2]);
+         String propsFile   = args[3];
+         String docList     = args[4];
+         String inputDir    = args[5];
+         String inputSuffix = args[6];
+         String outputFile  = args[7];
+         */
+		System.out.println("EntitySetIndexerThread(" + FileNameSchema.getTermsFileName(corpusName) + ", " + inType + ", " + String.valueOf(cutoff) + ", onomaprops, " + selectedCorpus.getDocListFileName() + ", " + selectedCorpus.getDirectory() + "...)");
         EntitySetIndexerThread indexer = new EntitySetIndexerThread(
                 FileNameSchema.getTermsFileName(selectedCorpus.getName()),
                 inType,
@@ -59,9 +75,13 @@ public class EntitySetBuilder {
         indexer.start();
     }
 
-    public List<String> suggestSeeds() {
-        return  EntitySetExpander.recommendSeeds(FileNameSchema.getEntitySetIndexFileName(Ice.selectedCorpus.name, type),
-                Ice.selectedCorpus.termFileName, type);
+	public List<String> suggestSeeds() {
+		return suggestSeeds(Ice.selectedCorpusName);
+	}
+
+    public List<String> suggestSeeds(String corpusName) {
+        return  EntitySetExpander.recommendSeeds(FileNameSchema.getEntitySetIndexFileName(corpusName, type),
+			 FileNameSchema.getTermsFileName(corpusName), type);
     }
 
     private List<String> splitSeedString(String seedString) {
@@ -76,11 +96,16 @@ public class EntitySetBuilder {
 
     public List<Entity> rankEntities(String seedString) {
 
-        Corpus selectedCorpus = Ice.selectedCorpus;
+        String corpusName = Ice.selectedCorpusName;
+		return rankEntities(corpusName, seedString);
 
+	}
+
+	public List<Entity> rankEntities(String corpusName, String seedString) {
         List<String> seedStrings = splitSeedString(seedString);
+		String entitySetIndexFileName = FileNameSchema.getEntitySetIndexFileName(corpusName, type);
 
-        EntitySetExpander expander = new EntitySetExpander(selectedCorpus.name + "EntitySetIndex_" + type,
+        EntitySetExpander expander = new EntitySetExpander(entitySetIndexFileName,
                 seedStrings);
 
         expander.rank();
@@ -237,7 +262,6 @@ public class EntitySetBuilder {
                             JOptionPane.ERROR_MESSAGE);
                     return;
                 }
-
                 buildIndex(cutoff, type);
             }
         });

--- a/src/main/java/edu/nyu/jet/ice/uicomps/Ice.java
+++ b/src/main/java/edu/nyu/jet/ice/uicomps/Ice.java
@@ -31,6 +31,7 @@ public class Ice {
 	public static SortedMap<String, IceRelation> relations = new TreeMap<String, IceRelation>();
 	public static Corpus selectedCorpus = null;
 	public static String selectedCorpusName = null;
+	public static String workingDirectory = null;
 
 	static JTextField directoryField;
 	static JTextField filterField;
@@ -140,7 +141,7 @@ public class Ice {
                 continue;
             if (Ice.corpora.get(corpus).wordCountFileName == null)
                 continue;
-            if (Ice.corpora.get(corpus).relationTypeFileName == null)
+            if (Ice.corpora.get(corpus).relationTypesFileName == null)
                 continue;
             JRadioButton button = new JRadioButton(corpus);
             bggroup.add(button);

--- a/src/main/java/edu/nyu/jet/ice/uicomps/RelationBuilder.java
+++ b/src/main/java/edu/nyu/jet/ice/uicomps/RelationBuilder.java
@@ -149,7 +149,8 @@ public class RelationBuilder {
     }
 
     public IceRelation createIceRelation(List<String> pathReprs) throws IllegalArgumentException{
-        DepPathMap depPathMap = DepPathMap.getInstance();
+		String corpusName = Ice.selectedCorpus.getName();
+        DepPathMap depPathMap = DepPathMap.getInstance(corpusName);
         List<String> pathList = new ArrayList<String>();
         String arg1type = null;
         String arg2type = null;

--- a/src/main/java/edu/nyu/jet/ice/uicomps/RelationBuilderFrame.java
+++ b/src/main/java/edu/nyu/jet/ice/uicomps/RelationBuilderFrame.java
@@ -119,6 +119,7 @@ public class RelationBuilderFrame extends JFrame {
 
         iterateButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent actionEvent) {
+		String corpusName = Ice.selectedCorpus.getName();
                 java.util.List<IcePath> approvedPaths = new ArrayList<IcePath>();
                 java.util.List<IcePath> rejectedPaths = new ArrayList<IcePath>();
                 for (Object o : rankedListModel.toArray()) {
@@ -140,98 +141,101 @@ public class RelationBuilderFrame extends JFrame {
                         5
                 ));
 
-                BootstrapIterateThread thread = new BootstrapIterateThread(bootstrap,
-                        approvedPaths,
-                        rejectedPaths,
-                        RelationBuilderFrame.this
-                        );
+                BootstrapIterateThread thread = new BootstrapIterateThread(
+		   corpusName,
+		   bootstrap,
+		   approvedPaths,
+		   rejectedPaths,
+		   RelationBuilderFrame.this
+									   );
                 thread.start();
             }
         });
 
         saveButton.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent actionEvent) {
-                java.util.List<IcePath> approvedPaths = new ArrayList<IcePath>();
-                java.util.List<IcePath> rejectedPaths = new ArrayList<IcePath>();
-                for (Object o : rankedListModel.toArray()) {
-                    IcePath e = (IcePath) o;
-                    if (e.getChoice() == IcePath.IcePathChoice.YES) {
-                        approvedPaths.add(e);
-                    }
-                    if (e.getChoice() == IcePath.IcePathChoice.NO) {
-                        rejectedPaths.add(e);
-                    }
-                }
+          public void actionPerformed(ActionEvent actionEvent) {
+	    String corpusName = Ice.selectedCorpus.getName();
+	    java.util.List<IcePath> approvedPaths = new ArrayList<IcePath>();
+	    java.util.List<IcePath> rejectedPaths = new ArrayList<IcePath>();
+	    for (Object o : rankedListModel.toArray()) {
+		IcePath e = (IcePath) o;
+		if (e.getChoice() == IcePath.IcePathChoice.YES) {
+		    approvedPaths.add(e);
+		}
+		if (e.getChoice() == IcePath.IcePathChoice.NO) {
+		    rejectedPaths.add(e);
+		}
+	    }
 
-                bootstrap.addPathsToSeedSet(approvedPaths, bootstrap.getSeedPaths());
-                bootstrap.addPathsToSeedSet(rejectedPaths, bootstrap.getRejects());
-                DepPathMap depPathMap = DepPathMap.getInstance();
-                StringBuilder text = new StringBuilder();
-                Set<String> usedRepr = new HashSet<String>();
-                for (String path : bootstrap.getSeedPaths()) {
-                    StringBuilder t = new StringBuilder();
-                    t.append(bootstrap.getArg1Type())
-                            .append(" -- ")
-                            .append(path)
-                            .append(" -- ")
-                            .append(bootstrap.getArg2Type());
-                    String repr = depPathMap.findRepr(t.toString());
-                    if (repr != null && !usedRepr.contains(repr)) {
-                        text.append(repr).append("\n");
-                        usedRepr.add(repr);
-                    }
-                }
-                if (relationBuilder != null) {
-                    relationBuilder.textArea.setText(text.toString());
-                }
-                if (swingRelationsPanel != null) {
-                    String[] reprs = text.toString().trim().split("\n");
-                    java.util.List<String> paths = Arrays.asList(reprs);
-                    swingRelationsPanel.updateEntriesListModel(paths);
-                }
-                // swingRelationsPanel.negPaths.clear();
-                java.util.List<String> paths = new ArrayList<String>();
-                for (String negPath : bootstrap.getRejects()) {
-                    // swingRelationsPanel.negPaths
-                    paths.add(bootstrap.getArg1Type() + " -- " +
-                        negPath + " -- " + bootstrap.getArg2Type());
-                }
-                swingRelationsPanel.negPaths.put(bootstrap.getRelationName(),
-                        paths);
-                RelationBuilderFrame.this.dispose();
-            }
-        });
+	    bootstrap.addPathsToSeedSet(approvedPaths, bootstrap.getSeedPaths());
+	    bootstrap.addPathsToSeedSet(rejectedPaths, bootstrap.getRejects());
+	    DepPathMap depPathMap = DepPathMap.getInstance(corpusName);
+	    StringBuilder text = new StringBuilder();
+	    Set<String> usedRepr = new HashSet<String>();
+	    for (String path : bootstrap.getSeedPaths()) {
+		StringBuilder t = new StringBuilder();
+		t.append(bootstrap.getArg1Type())
+		    .append(" -- ")
+		    .append(path)
+		    .append(" -- ")
+		    .append(bootstrap.getArg2Type());
+		String repr = depPathMap.findRepr(t.toString());
+		if (repr != null && !usedRepr.contains(repr)) {
+		    text.append(repr).append("\n");
+		    usedRepr.add(repr);
+		}
+	    }
+	    if (relationBuilder != null) {
+		relationBuilder.textArea.setText(text.toString());
+	    }
+	    if (swingRelationsPanel != null) {
+		String[] reprs = text.toString().trim().split("\n");
+		java.util.List<String> paths = Arrays.asList(reprs);
+		swingRelationsPanel.updateEntriesListModel(paths);
+	    }
+	    // swingRelationsPanel.negPaths.clear();
+	    java.util.List<String> paths = new ArrayList<String>();
+	    for (String negPath : bootstrap.getRejects()) {
+		// swingRelationsPanel.negPaths
+		paths.add(bootstrap.getArg1Type() + " -- " +
+			  negPath + " -- " + bootstrap.getArg2Type());
+	    }
+	    swingRelationsPanel.negPaths.put(bootstrap.getRelationName(),
+					     paths);
+	    RelationBuilderFrame.this.dispose();
+	  }
+	    });
 
         // handle the click of [Exit]
         exitButton.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent actionEvent) {
+		public void actionPerformed(ActionEvent actionEvent) {
+		    
 
-
-                RelationBuilderFrame.this.dispose();
-            }
-        });
+		    RelationBuilderFrame.this.dispose();
+		}
+	    });
 
         // handle the click of [x]
         this.addWindowListener(new WindowAdapter() {
-            public void windowClosing(WindowEvent e) {
-                RelationBuilderFrame.this.dispose();
-
-            }
-        });
+		public void windowClosing(WindowEvent e) {
+		    RelationBuilderFrame.this.dispose();
+		    
+		}
+	    });
 
         // adapters
 
         rankedList.addMouseMotionListener(new MouseMotionAdapter() {
-            @Override
-            public void mouseMoved(MouseEvent e) {
-                JList l = (JList)e.getSource();
-                ListModel m = l.getModel();
-                int index = l.locationToIndex(e.getPoint());
-                if( index>-1 ) {
-                    l.setToolTipText(((IcePath)m.getElementAt(index)).getExample());
-                }
-            }
-        });
+		@Override
+		    public void mouseMoved(MouseEvent e) {
+		    JList l = (JList)e.getSource();
+		    ListModel m = l.getModel();
+		    int index = l.locationToIndex(e.getPoint());
+		    if( index>-1 ) {
+			l.setToolTipText(((IcePath)m.getElementAt(index)).getExample());
+		    }
+		}
+	    });
 
 
 
@@ -243,20 +247,20 @@ public class RelationBuilderFrame extends JFrame {
         rankedList.getInputMap().put(KeyStroke.getKeyStroke("U"), "UNDECIDED");
         rankedList.getInputMap().put(KeyStroke.getKeyStroke("u"), "UNDECIDED");
         rankedList.getActionMap().put("YES", new AbstractAction() {
-            public void actionPerformed(ActionEvent actionEvent) {
-                yesButton.doClick();
-            }
-        });
+		public void actionPerformed(ActionEvent actionEvent) {
+		    yesButton.doClick();
+		}
+	    });
         rankedList.getActionMap().put("NO", new AbstractAction() {
-            public void actionPerformed(ActionEvent actionEvent) {
-                noButton.doClick();
-            }
-        });
+		public void actionPerformed(ActionEvent actionEvent) {
+		    noButton.doClick();
+		}
+	    });
         rankedList.getActionMap().put("UNDECIDED", new AbstractAction() {
-            public void actionPerformed(ActionEvent actionEvent) {
-                undecidedButton.doClick();
-            }
-        });
+		public void actionPerformed(ActionEvent actionEvent) {
+		    undecidedButton.doClick();
+		}
+	    });
     }
 
 //    private void saveEntitySetToAuxFile(String typeName) {
@@ -313,11 +317,13 @@ class BootstrapIterateThread extends Thread {
     java.util.List<IcePath> approvedPaths;
     java.util.List<IcePath> rejectedPaths;
     RelationBuilderFrame frame;
+    String corpusName;
 
-    BootstrapIterateThread(Bootstrap bootstrap,
+    BootstrapIterateThread(String corpusName, Bootstrap bootstrap,
                            java.util.List<IcePath> approvedPaths,
                            java.util.List<IcePath> rejectedPaths,
                            RelationBuilderFrame frame) {
+	this.corpusName = corpusName;
         this.bootstrap = bootstrap;
         this.approvedPaths = approvedPaths;
         this.rejectedPaths = rejectedPaths;
@@ -325,7 +331,7 @@ class BootstrapIterateThread extends Thread {
     }
 
     public void run() {
-        bootstrap.iterate(approvedPaths, rejectedPaths);
+        bootstrap.iterate(corpusName, approvedPaths, rejectedPaths);
         frame.updateList();
         frame.listPane.validate();
         frame.listPane.repaint();

--- a/src/main/java/edu/nyu/jet/ice/uicomps/RelationBuilderThread.java
+++ b/src/main/java/edu/nyu/jet/ice/uicomps/RelationBuilderThread.java
@@ -1,6 +1,7 @@
 package edu.nyu.jet.ice.uicomps;
 
 import edu.nyu.jet.ice.relation.Bootstrap;
+import edu.nyu.jet.ice.utils.FileNameSchema;
 import edu.nyu.jet.ice.views.swing.SwingRelationsPanel;
 
 /**
@@ -16,9 +17,10 @@ public class RelationBuilderThread extends Thread {
     RelationBuilderFrame frame;
     SwingRelationsPanel swingRelationsPanel;
 
-    public RelationBuilderThread(String seed, String relationInstanceFileName,
-                          String pathListFileName, RelationBuilder builder, Bootstrap bootstrap,
-                          RelationBuilderFrame frame, SwingRelationsPanel swingRelationsPanel) {
+    public RelationBuilderThread(
+      String seed, String relationInstanceFileName,
+      String pathListFileName, RelationBuilder builder, Bootstrap bootstrap,
+      RelationBuilderFrame frame, SwingRelationsPanel swingRelationsPanel) {
         args = new String[3];
         args[0] = seed;
         String[] parts = seed.trim().toLowerCase().split(" ");

--- a/src/main/java/edu/nyu/jet/ice/utils/FileNameSchema.java
+++ b/src/main/java/edu/nyu/jet/ice/utils/FileNameSchema.java
@@ -1,5 +1,6 @@
 package edu.nyu.jet.ice.utils;
 
+import edu.nyu.jet.ice.uicomps.Ice;
 import java.io.File;
 import java.io.IOException;
 //import java.nio.file.Files;
@@ -14,6 +15,7 @@ import java.io.IOException;
  */
 public class FileNameSchema {
     private static String CACHE_ROOT = "cache";
+    private static String entitySetIndexPrefix = "EntitySetIndex_";
 
     static {
         File cacheFile = new File(CACHE_ROOT);
@@ -28,9 +30,28 @@ public class FileNameSchema {
         }
     }
 
+    public static String getWD() {
+	return Ice.workingDirectory;
+    }
 
     public static String getCacheRoot() {
         return CACHE_ROOT;
+    }
+
+    public static String getCorpusNameFromDocList (String docListName) {
+	return docListName.split(File.separator)[0].split("\\.")[0];
+    }
+
+    public static String getCorpusNameFromTermsFile (String termsFileName) {
+	return termsFileName.split(File.separator)[1];
+    }
+
+    public static String getCorpusNameFromWordCountFileName (String wcfName) {
+	return wcfName.split(File.separator)[1];
+    }
+
+    public static String getCorpusNameFromPatternFileName (String patternFileName) {
+	return patternFileName.split(File.separator)[1];
     }
 
     public static String getPreprocessCacheDir(String corpusName) {
@@ -43,6 +64,10 @@ public class FileNameSchema {
 
     public static String getDocListFileName(String corpusName) {
         return CACHE_ROOT + File.separator + corpusName + File.separator + "docList";
+    }
+
+    public static String getPreprocessedDocListFileName(String corpusName) {
+        return CACHE_ROOT + File.separator + corpusName + File.separator + "docList.local";
     }
 
     public static String getTermsFileName(String corpusName) {
@@ -66,10 +91,14 @@ public class FileNameSchema {
     }
 
     public static String getEntitySetIndexFileName(String corpusName, String inType) {
-        return CACHE_ROOT + File.separatorChar + corpusName + File.separator + "EntitySetIndex_" + inType;
+	return getEntitySetIndexFileName(corpusName, inType, 3.0);
+    }
+    public static String getEntitySetIndexFileName(String corpusName, String inType, Double cutoff) {
+	String cutoffStr = String.valueOf(cutoff).replace('.', 'p');
+        return CACHE_ROOT + File.separatorChar + corpusName + File.separator + entitySetIndexPrefix + inType + "_" + cutoffStr;
     }
 
-    public static String getPatternRatioFileName(String corpusName, String bgCorpusName) {
+public static String getPatternRatioFileName(String corpusName, String bgCorpusName) {
         return CACHE_ROOT + File.separatorChar + corpusName + File.separator + bgCorpusName + "-Pattern-Ratio";
     }
 

--- a/src/main/java/edu/nyu/jet/ice/utils/IceUtils.java
+++ b/src/main/java/edu/nyu/jet/ice/utils/IceUtils.java
@@ -238,8 +238,8 @@ public class IceUtils {
         int count = 0;
         for (Corpus corpus : Ice.corpora.values()) {
             if (corpus.wordCountFileName != null &&
-                    (corpus.relationTypeFileName != null &&
-                            !corpus.relationTypeFileName.trim().equals("~"))) {
+                    (corpus.relationTypesFileName != null &&
+                            !corpus.relationTypesFileName.trim().equals("~"))) {
                 count++;
             }
         }

--- a/src/main/java/edu/nyu/jet/ice/views/cli/IceCLI.java
+++ b/src/main/java/edu/nyu/jet/ice/views/cli/IceCLI.java
@@ -381,13 +381,13 @@ public class IceCLI {
                         Ice.selectedCorpus.numberOfDocs,
                         null);
                 finder.run();
-                Ice.selectedCorpus.relationTypeFileName =
+                Ice.selectedCorpus.relationTypesFileName =
                         FileNameSchema.getRelationTypesFileName(Ice.selectedCorpus.name);
                 Ice.selectedCorpus.relationInstanceFileName =
                         FileNameSchema.getRelationsFileName(Ice.selectedCorpusName);
                 if (Ice.selectedCorpus.backgroundCorpus != null) {
                     System.err.println("Generating path ratio file by comparing phrases in background corpus.");
-                    Corpus.rankRelations(Ice.selectedCorpus.backgroundCorpus,
+                    Corpus.rankRelations(Ice.selectedCorpusName, Ice.selectedCorpus.backgroundCorpus,
                             FileNameSchema.getPatternRatioFileName(Ice.selectedCorpusName,
                                     Ice.selectedCorpus.backgroundCorpus));
                 }

--- a/src/main/java/edu/nyu/jet/ice/views/cli/IceCLI6.java
+++ b/src/main/java/edu/nyu/jet/ice/views/cli/IceCLI6.java
@@ -292,13 +292,14 @@ public class IceCLI6 {
                         Ice.selectedCorpus.numberOfDocs,
                         null);
                 finder.run();
-                Ice.selectedCorpus.relationTypeFileName =
+                Ice.selectedCorpus.relationTypesFileName =
                         FileNameSchema.getRelationTypesFileName(Ice.selectedCorpus.name);
                 Ice.selectedCorpus.relationInstanceFileName =
                         FileNameSchema.getRelationsFileName(Ice.selectedCorpusName);
                 if (Ice.selectedCorpus.backgroundCorpus != null) {
                     System.err.println("Generating path ratio file by comparing phrases in background corpus.");
-                    Corpus.rankRelations(Ice.selectedCorpus.backgroundCorpus,
+                    Corpus.rankRelations(Ice.selectedCorpusName,
+					 Ice.selectedCorpus.backgroundCorpus,
                             FileNameSchema.getPatternRatioFileName(Ice.selectedCorpusName,
                                     Ice.selectedCorpus.backgroundCorpus));
                 }

--- a/src/main/java/edu/nyu/jet/ice/views/swing/SwingCorpusPanel.java
+++ b/src/main/java/edu/nyu/jet/ice/views/swing/SwingCorpusPanel.java
@@ -175,13 +175,24 @@ public class SwingCorpusPanel extends JComponent implements Refreshable {
                     return;
                 }
                 setFilter(filterTextField.getText());
+		System.out.println("About to create IcePreprocessor");
+		System.out.println("Ice.selectedCorpusName = " + Ice.selectedCorpusName);
+		System.out.println("Ice.selectedCorpus.docListFileName = " + Ice.selectedCorpus.docListFileName);
                 IcePreprocessor icePreprocessor = new IcePreprocessor(
-                        Ice.selectedCorpus.directory,
-                        Ice.iceProperties.getProperty("Ice.IcePreprocessor.parseprops"),
-                        Ice.selectedCorpus.docListFileName,
-                        filterTextField.getText(),
-                        FileNameSchema.getPreprocessCacheDir(Ice.selectedCorpusName)
+                  Ice.selectedCorpusName,
+		  Ice.iceProperties.getProperty("Ice.IcePreprocessor.parseprops"),
+		  filterTextField.getText()
+								      );
+
+		/*
+                IcePreprocessor icePreprocessor = new IcePreprocessor(
+		  Ice.selectedCorpus.directory,
+		  Ice.iceProperties.getProperty("Ice.IcePreprocessor.parseprops"),
+		  Ice.selectedCorpus.docListFileName,
+		  filterTextField.getText(),
+		  FileNameSchema.getPreprocessCacheDir(Ice.selectedCorpusName)
                 );
+		*/
                 SwingProgressMonitor progressMonitor = new SwingProgressMonitor(SwingCorpusPanel.this,
                         "Preprocessing files",
                         "Processing files with Jet...",
@@ -293,7 +304,7 @@ public class SwingCorpusPanel extends JComponent implements Refreshable {
                 continue;
             if (Ice.corpora.get(corpus).wordCountFileName == null)
                 continue;
-            if (Ice.corpora.get(corpus).relationTypeFileName == null)
+            if (Ice.corpora.get(corpus).relationTypesFileName == null)
                 continue;
             if (corpus.startsWith(".")) {
                 continue;
@@ -328,10 +339,13 @@ public class SwingCorpusPanel extends JComponent implements Refreshable {
 
     public void addCorpus(String corpusName) {
         Corpus newCorpus = new Corpus(corpusName);
+	newCorpus.setTermFileName(FileNameSchema.getTermsFileName(corpusName));
         Ice.corpora.put(corpusName, newCorpus);
         corpusSelectionComboBox.addItem(corpusName);
         corpusSelectionComboBox.setSelectedItem(corpusName);
         Ice.selectCorpus(corpusName);
+	System.out.println("Added corpus " + corpusName);
+	System.out.println("Ice.selectedCorpus is " + Ice.selectedCorpusName);
         refresh();
     }
 

--- a/src/main/java/edu/nyu/jet/ice/views/swing/SwingEntitySetPanel.java
+++ b/src/main/java/edu/nyu/jet/ice/views/swing/SwingEntitySetPanel.java
@@ -159,11 +159,21 @@ public class SwingEntitySetPanel extends JPanel implements Refreshable {
                 Timer timer = switchToBusyCursor(SwingEntitySetPanel.this);
                 String seedString = null;
                 List<String> seeds = null;
-                if (Ice.selectedCorpus.termFileName == null ||
-                        FileNameSchema.getEntitySetIndexFileName(Ice.selectedCorpusName, "nn") == null ||
-                        !(new File(FileNameSchema.getEntitySetIndexFileName(Ice.selectedCorpusName, "nn"))).exists()) {
+		String esiFileName = FileNameSchema.getEntitySetIndexFileName(Ice.selectedCorpusName, "nn");
+		System.out.println("SwingEntitySetPanel: Testing for entitySetIndex file " + esiFileName);
+		String fileError = "";
+		// TODO find out where term file can be set
+		String termFileName = Ice.selectedCorpus.termFileName;
+		System.out.println("Testing for termFileName " + termFileName);
+                if (Ice.selectedCorpus.termFileName == null) {
+		    fileError = "Term file does not exist.";
+		} else if (esiFileName == null ||
+			   !(new File(esiFileName).exists())) {
+		    fileError = "Entity index file does not exist.";
+		}
+		if (fileError.length() > 0) {
                     JOptionPane.showMessageDialog(Ice.mainFrame,
-                            "Entity index file does not exist. Please run indexing first.",
+                            fileError + " Please run indexing first.",
                             "Index entities first",
                             JOptionPane.ERROR_MESSAGE);
                     switchToNormalCursor(SwingEntitySetPanel.this, timer);

--- a/src/main/java/edu/nyu/jet/ice/views/swing/SwingPathsPanel.java
+++ b/src/main/java/edu/nyu/jet/ice/views/swing/SwingPathsPanel.java
@@ -89,8 +89,8 @@ public class SwingPathsPanel extends JPanel implements Refreshable {
     public void checkForAndFindRelations(ProgressMonitorI progressMonitor,
                                          boolean sententialOnly) {
         String relationInstanceFileName = FileNameSchema.getRelationsFileName(Ice.selectedCorpusName);//name + "Relations";
-        String relationTypeFileName = FileNameSchema.getRelationTypesFileName(Ice.selectedCorpusName);//name + "Relationtypes";
-        File file = new File(relationTypeFileName);
+        String relationTypesFileName = FileNameSchema.getRelationTypesFileName(Ice.selectedCorpusName);//name + "Relationtypes";
+        File file = new File(relationTypesFileName);
         boolean shouldReuse = false;
         if (file.exists() &&
                 !file.isDirectory()) {
@@ -101,7 +101,7 @@ public class SwingPathsPanel extends JPanel implements Refreshable {
                     JOptionPane.YES_NO_OPTION);
             if (n == 0) { // reuse existing paths
                 shouldReuse = true;
-//                Corpus.displayTerms(relationTypeFileName,
+//                Corpus.displayTerms(relationTypesFileName,
 //                        40,
 //                        relationTextArea,
 //                        relationFilter);
@@ -145,17 +145,18 @@ class PathExtractionThread extends Thread {
                     Ice.selectedCorpus.numberOfDocs,
                     progressMonitor);
             finder.run();
-            Ice.selectedCorpus.relationTypeFileName =
+            Ice.selectedCorpus.relationTypesFileName =
                     FileNameSchema.getRelationTypesFileName(Ice.selectedCorpus.name);
             Ice.selectedCorpus.relationInstanceFileName =
                     FileNameSchema.getRelationsFileName(Ice.selectedCorpusName);
         }
         progressMonitor.setNote("Postprocessing...");
         // rank paths
-        Corpus.rankRelations(Ice.selectedCorpus.backgroundCorpus,
+        Corpus.rankRelations(Ice.selectedCorpusName,
+			     Ice.selectedCorpus.backgroundCorpus,
                 FileNameSchema.getPatternRatioFileName(Ice.selectedCorpusName,
                         Ice.selectedCorpus.backgroundCorpus));
-        DepPathMap depPathMap = DepPathMap.getInstance();
+        DepPathMap depPathMap = DepPathMap.getInstance(Ice.selectedCorpusName);
         depPathMap.load();
         // filter and show paths
         try {

--- a/src/main/java/edu/nyu/jet/ice/views/swing/SwingRelationsPanel.java
+++ b/src/main/java/edu/nyu/jet/ice/views/swing/SwingRelationsPanel.java
@@ -170,8 +170,8 @@ public class SwingRelationsPanel extends JPanel implements Refreshable {
         // listeners
 
         relationList.addListSelectionListener(new ListSelectionListener() {
-            public void valueChanged(ListSelectionEvent listSelectionEvent) {
-                refresh();
+          public void valueChanged(ListSelectionEvent listSelectionEvent) {
+            refresh();
 //                int idx = relationList.getSelectedIndex();
 //                if (idx < 0) return;
 //                IceRelation iceRelation = (IceRelation) relationListModel.getElementAt(idx);
@@ -185,89 +185,91 @@ public class SwingRelationsPanel extends JPanel implements Refreshable {
 //                }
 //                entriesListModel = newListModel;
 //                entriesList.setModel(entriesListModel);
-            }
-        });
+	  }
+	    });
 
         addRelationButton.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent actionEvent) {
-                String relationName = JOptionPane.showInputDialog("Name of the relation");
-                if (relationName == null) {
-                    return;
-                }
-                relationName = relationName.toUpperCase();
-                for (Object existingRelation : relationListModel.toArray()) {
-                    if (existingRelation.toString().equals(relationName)) {
-                        JOptionPane.showMessageDialog(SwingRelationsPanel.this,
-                                "The name is already in use by another relation.",
-                                "Relation Name Error",
-                                JOptionPane.ERROR_MESSAGE);
-                        return;
-                    }
-                }
-                String relationInstance = JOptionPane.showInputDialog(
-                        "Please provide an example of the relation");
-                if (relationInstance == null) {
-                    return;
-                }
-                DepPathMap depPathMap = DepPathMap.getInstance();
-                depPathMap.load();
-                List<String> paths = depPathMap.findPath(relationInstance);
-                if (paths == null) {
-                    JOptionPane.showMessageDialog(SwingRelationsPanel.this,
-                            String.format("No example in the corpus for [%s]", relationInstance),
+          public void actionPerformed(ActionEvent actionEvent) {
+            String relationName = JOptionPane.showInputDialog("Name of the relation");
+	    if (relationName == null) {
+		return;
+	    }
+	    relationName = relationName.toUpperCase();
+	    for (Object existingRelation : relationListModel.toArray()) {
+		if (existingRelation.toString().equals(relationName)) {
+		    JOptionPane.showMessageDialog(SwingRelationsPanel.this,
+						  "The name is already in use by another relation.",
+						  "Relation Name Error",
+						  JOptionPane.ERROR_MESSAGE);
+		    return;
+		}
+	    }
+	    String relationInstance = JOptionPane.showInputDialog(
+	      "Please provide an example of the relation");
+	    if (relationInstance == null) {
+		return;
+	    }
+	    String corpusName = Ice.selectedCorpus.getName();
+	    DepPathMap depPathMap = DepPathMap.getInstance(corpusName);
+	    depPathMap.load();
+	    List<String> paths = depPathMap.findPath(relationInstance);
+	    if (paths == null) {
+	      JOptionPane.showMessageDialog(SwingRelationsPanel.this,
+                String.format("No example in the corpus for [%s]", relationInstance),
                             "Dependency Path Error",
                             JOptionPane.ERROR_MESSAGE);
-                    return;
-                }
-                installSeedRelation(relationName, paths);
-                // System.err.println(path);
-            }
+	      return;
+	    }
+	    installSeedRelation(relationName, paths);
+	    // System.err.println(path);
+	  }
         });
 
         suggestRelationButton.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent actionEvent) {
-                java.util.Timer timer = switchToBusyCursor(SwingRelationsPanel.this);
-                String relationInstance = null;
-                try {
-                    relationInstance = suggestRelation();
-                }
-                finally {
-                    switchToNormalCursor(SwingRelationsPanel.this, timer);
-                }
-                if (relationInstance != null) {
-                    int n = JOptionPane.showConfirmDialog(
-                            SwingRelationsPanel.this,
-                            String.format("Do you want to start with path [%s]?", relationInstance),
-                            "Path Suggestion",
-                            JOptionPane.YES_NO_OPTION);
-                    if (n == 0) {
-                        String relationName = JOptionPane.showInputDialog("Name of the relation");
-                        if (relationName == null) {
-                            return;
-                        }
-                        relationName = relationName.toUpperCase();
-                        for (Object existingRelation : relationListModel.toArray()) {
-                            if (existingRelation.toString().equals(relationName)) {
-                                JOptionPane.showMessageDialog(SwingRelationsPanel.this,
-                                        "The name is already used by another relation.",
-                                        "Relation Name Error",
-                                        JOptionPane.ERROR_MESSAGE);
-                                return;
-                            }
-                        }
-                        DepPathMap depPathMap = DepPathMap.getInstance();
-                        List<String> paths = depPathMap.findPath(relationInstance);
-                        if (paths == null) {
-                            JOptionPane.showMessageDialog(SwingRelationsPanel.this,
-                                    "The provided path is invalid.",
-                                    "Dependency Path Error",
-                                    JOptionPane.ERROR_MESSAGE);
-                            return;
-                        }
-                        installSeedRelation(relationName, paths);
-                    }
-                }
-            }
+          public void actionPerformed(ActionEvent actionEvent) {
+            java.util.Timer timer = switchToBusyCursor(SwingRelationsPanel.this);
+	    String relationInstance = null;
+	    String corpusName = Ice.selectedCorpus.getName();
+	    try {
+		relationInstance = suggestRelation();
+	    }
+	    finally {
+		switchToNormalCursor(SwingRelationsPanel.this, timer);
+	    }
+	    if (relationInstance != null) {
+		int n = JOptionPane.showConfirmDialog(
+	          SwingRelationsPanel.this,
+		  String.format("Do you want to start with path [%s]?", relationInstance),
+		  "Path Suggestion",
+		  JOptionPane.YES_NO_OPTION);
+		if (n == 0) {
+		  String relationName = JOptionPane.showInputDialog("Name of the relation");
+		  if (relationName == null) {
+		    return;
+		  }
+		  relationName = relationName.toUpperCase();
+		  for (Object existingRelation : relationListModel.toArray()) {
+		    if (existingRelation.toString().equals(relationName)) {
+		      JOptionPane.showMessageDialog(SwingRelationsPanel.this,
+			"The name is already used by another relation.",
+						    "Relation Name Error",
+						    JOptionPane.ERROR_MESSAGE);
+		      return;
+		    }
+		  }
+		  DepPathMap depPathMap = DepPathMap.getInstance(corpusName);
+		  List<String> paths = depPathMap.findPath(relationInstance);
+		  if (paths == null) {
+		      JOptionPane.showMessageDialog(SwingRelationsPanel.this,
+			"The provided path is invalid.",
+						    "Dependency Path Error",
+						    JOptionPane.ERROR_MESSAGE);
+		      return;
+		  }
+		  installSeedRelation(relationName, paths);
+		}
+	    }
+	  }
         });
 
         expandEntriesButton.addActionListener(new ActionListener() {
@@ -287,9 +289,10 @@ public class SwingRelationsPanel extends JPanel implements Refreshable {
         addEntryButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent actionEvent) {
                 if (entriesListModel == null) return;
+		String corpusName = Ice.selectedCorpus.getName();
                 String relationInstance = JOptionPane.showInputDialog(
                         "Please provide an example of the relation");
-                DepPathMap depPathMap = DepPathMap.getInstance();
+                DepPathMap depPathMap = DepPathMap.getInstance(corpusName);
                 if (relationInstance == null) {
                     return;
                 }
@@ -336,12 +339,13 @@ public class SwingRelationsPanel extends JPanel implements Refreshable {
                         entriesListModel.size() == 0) {
                     return;
                 }
+		String corpusName = Ice.selectedCorpus.getName();
                 currentRelation.setName(nameTextField.getText().trim());
                 currentRelation.setArg1type(arg1TextField.getText());
                 currentRelation.setArg2type(arg2TextField.getText());
                 java.util.List<String> relationPaths = new ArrayList<String>();
                 for (Object e : entriesListModel.toArray()) {
-                    DepPathMap depPathMap = DepPathMap.getInstance();
+                    DepPathMap depPathMap = DepPathMap.getInstance(corpusName);
                     List<String> paths = depPathMap.findPath(e.toString());
                     if (paths != null) {
                         for (String path : paths) {
@@ -463,6 +467,7 @@ public class SwingRelationsPanel extends JPanel implements Refreshable {
         iceStatusPanel.refresh();
         int idx = relationList.getSelectedIndex();
         if (idx < 0) return;
+	String corpusName = Ice.selectedCorpus.getName();
         // System.err.println(idx);
         IceRelation relation = (IceRelation)relationListModel.getElementAt(idx);
         // System.err.println(relation.getType());
@@ -476,7 +481,7 @@ public class SwingRelationsPanel extends JPanel implements Refreshable {
         arg1TextField.setText(relation.getArg1type());
         arg2TextField.setText(relation.getArg2type());
         DefaultListModel newListModel = new DefaultListModel();
-        DepPathMap depPathMap = DepPathMap.getInstance();
+        DepPathMap depPathMap = DepPathMap.getInstance(corpusName);
         depPathMap.load();
         for (String path : relation.getPaths()) {
             String fullPath = relation.getArg1type() +
@@ -507,11 +512,13 @@ public class SwingRelationsPanel extends JPanel implements Refreshable {
     }
 
     public String suggestRelation() {
+	String corpusName = Ice.selectedCorpus.getName();
         String result = "";
         try {
+
             String[] lines =
-                    IceUtils.readLines(FileNameSchema.getRelationTypesFileName(Ice.selectedCorpusName));
-            DepPathMap depPathMap = DepPathMap.getInstance();
+                    IceUtils.readLines(FileNameSchema.getRelationTypesFileName(corpusName));
+            DepPathMap depPathMap = DepPathMap.getInstance(corpusName);
             depPathMap.load();
             for (String line : lines) {
                 String[] parts = line.split("\t");


### PR DESCRIPTION
The current version of ICE stores the selected corpus in **edu.nyu.jet.uicomps.Ice.selectedCorpus** (and **Ice.selectedCorpusName**) and refers to that whenever it needs to.

This is a problem if we want the user to be able to run multiple operations at the same time.  For example, the user may want to start a long preprocessing or indexing job on one corpus, and while that job is running view the extracted entities or patterns, or compile entity sets or relations, on another corpus.  In order to do that, they need to change the **selectedCorpus**.

In the current Swing system, changing the **selectedCorpus** in the middle of a job can wreak all kinds of havoc.  If the user starts preprocessing Corpus A and then selects Corpus B to view entities, the preprocessor will switch in the middle to preprocessing Corpus B, abandoning the preprocessing of Corpus A, wasting CPU cycles, corrupting the cache and ultimately crashing.

These updates make it so that each job has a foreground corpus assigned to it that doesn't change over the course of the job.
